### PR TITLE
More pseudo-classes

### DIFF
--- a/src/IconPacks.Avalonia.BoxIcons/PackIconBoxIcons.cs
+++ b/src/IconPacks.Avalonia.BoxIcons/PackIconBoxIcons.cs
@@ -33,6 +33,8 @@ namespace IconPacks.Avalonia
             {
                 UpdateData();
             }
+            
+            base.UpdateIconPseudoClasses(true, false, true);
         }
 
         protected override void SetKind<TKind>(TKind iconKind)

--- a/src/IconPacks.Avalonia.Core/PackIconControlBase.cs
+++ b/src/IconPacks.Avalonia.Core/PackIconControlBase.cs
@@ -6,6 +6,7 @@ using Avalonia;
 using Avalonia.Animation;
 using Avalonia.Animation.Easings;
 using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Media;
@@ -16,8 +17,29 @@ namespace IconPacks.Avalonia
     /// <summary>
     /// Class PackIconControlBase which is the base class for any PackIcon control.
     /// </summary>
+    [PseudoClasses(IconDataFlippedVerticallyPseudoClass)]
+    [PseudoClasses(IconFilledPseudoClass)]
+    [PseudoClasses(IconOutlinedPseudoClass)]
     public abstract class PackIconControlBase : PackIconBase
     {
+        /// <summary>
+        /// A string representing the pseudo-class when the icon data is flipped vertically
+        /// </summary>
+        /// <returns>":icon-data-flipped-vertically"</returns>
+        public const string IconDataFlippedVerticallyPseudoClass = ":icon-data-flipped-vertically";
+        
+        /// <summary>
+        /// A string representing the pseudo-class when the icon data is drawn filled
+        /// </summary>
+        /// <returns>":icon-filled"</returns>
+        public const string IconFilledPseudoClass = ":icon-filled";
+        
+        /// <summary>
+        /// A string representing the pseudo-class when the icon data is drawn outlined
+        /// </summary>
+        /// <returns>":icon-outlided"</returns>
+        public const string IconOutlinedPseudoClass = ":icon-outlined";
+        
         protected PackIconControlBase()
         {
             AffectsRender<PackIconControlBase>(SpinProperty, SpinDurationProperty, OpacityProperty, SpinEasingFunctionProperty, FlipProperty, RotationAngleProperty);
@@ -280,6 +302,13 @@ namespace IconPacks.Avalonia
         {
             get { return this.GetValue(SpinAutoReverseProperty); }
             set { this.SetValue(SpinAutoReverseProperty, value); }
+        }
+
+        protected void UpdateIconPseudoClasses(bool filled, bool outlined, bool flipped)
+        {
+            PseudoClasses.Set(IconFilledPseudoClass, filled);
+            PseudoClasses.Set(IconOutlinedPseudoClass, outlined);
+            PseudoClasses.Set(IconDataFlippedVerticallyPseudoClass, flipped);
         }
     }
 }

--- a/src/IconPacks.Avalonia/PackIconControl.cs
+++ b/src/IconPacks.Avalonia/PackIconControl.cs
@@ -10,14 +10,8 @@ namespace IconPacks.Avalonia
 {
     /// <summary>
     /// </summary>
-    [PseudoClasses(IconDataFlippedVerticallyPseudoClass)]
     public class PackIconControl : PackIconControlBase
     {
-        /// <summary>
-        /// A string representing the pseudo-class when the icon data is flipped vertically
-        /// </summary>
-        /// <returns>":icon-data-flipped-vertically"</returns>
-        public const string IconDataFlippedVerticallyPseudoClass = ":icon-data-flipped-vertically";
         
         public static readonly StyledProperty<Enum> KindProperty
             = AvaloniaProperty.Register<PackIconControl, Enum>(nameof(Kind));
@@ -53,11 +47,11 @@ namespace IconPacks.Avalonia
             switch(Kind)
             {
                 case PackIconBoxIconsKind:
-                    PseudoClasses.Set(IconDataFlippedVerticallyPseudoClass, true);
+                    UpdateIconPseudoClasses(true, false, true);
                     break;
                 
                 default:
-                    PseudoClasses.Set(IconDataFlippedVerticallyPseudoClass, false);
+                    UpdateIconPseudoClasses(true, false, false);
                     break;
             }
 

--- a/src/IconPacks.Avalonia/PackIconControl.cs
+++ b/src/IconPacks.Avalonia/PackIconControl.cs
@@ -10,9 +10,15 @@ namespace IconPacks.Avalonia
 {
     /// <summary>
     /// </summary>
-    [PseudoClasses(":PackIconBoxIcons")]
+    [PseudoClasses(IconDataFlippedVerticallyPseudoClass)]
     public class PackIconControl : PackIconControlBase
     {
+        /// <summary>
+        /// A string representing the pseudo-class when the icon data is flipped vertically
+        /// </summary>
+        /// <returns>":icon-data-flipped-vertically"</returns>
+        public const string IconDataFlippedVerticallyPseudoClass = ":icon-data-flipped-vertically";
+        
         public static readonly StyledProperty<Enum> KindProperty
             = AvaloniaProperty.Register<PackIconControl, Enum>(nameof(Kind));
 
@@ -44,7 +50,16 @@ namespace IconPacks.Avalonia
 
         protected override void UpdateData()
         {
-            this.PseudoClasses.Set(":PackIconBoxIcons", Kind is PackIconBoxIconsKind);
+            switch(Kind)
+            {
+                case PackIconBoxIconsKind:
+                    PseudoClasses.Set(IconDataFlippedVerticallyPseudoClass, true);
+                    break;
+                
+                default:
+                    PseudoClasses.Set(IconDataFlippedVerticallyPseudoClass, false);
+                    break;
+            }
 
             if (Kind != default(Enum))
             {

--- a/src/IconPacks.Avalonia/PackIconControl.xaml
+++ b/src/IconPacks.Avalonia/PackIconControl.xaml
@@ -3,7 +3,12 @@
                     xmlns:iconPacks="urn:iconpacks-avalonia"
                     xmlns:converter="clr-namespace:IconPacks.Avalonia.Converter;assembly=IconPacks.Avalonia.Core"
                     x:ClassModifier="internal">
-
+    
+    <Design.PreviewWith>
+        <iconPacks:PackIconBoxIcons Kind="RegularBowlingBall" />
+    </Design.PreviewWith>
+    
+    
     <ControlTemplate x:Key="IconPacks.Avalonia.PackIconControl.Template" TargetType="iconPacks:PackIconControl">
         <Grid>
             <Border Background="{TemplateBinding Background}"
@@ -12,7 +17,8 @@
             <Grid x:Name="PART_InnerGrid"
                   Margin="{TemplateBinding BorderThickness}"
                   RenderTransformOrigin="0.5 0.5">
-                <Viewbox Margin="{TemplateBinding Padding}">
+                <Viewbox x:Name="PART_ViewBox" 
+                         Margin="{TemplateBinding Padding}">
                     <Path x:Name="PART_IconPath"
                           Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={x:Static converter:NullToUnsetValueConverter.Instance}}"
                           Fill="{TemplateBinding Foreground}"
@@ -161,10 +167,12 @@
         <Setter Property="UseLayoutRounding" Value="False" />
         <Setter Property="Template" Value="{DynamicResource IconPacks.Avalonia.PackIconControl.Template}" />
 
-        <!-- <Style Selector="^[Kind=IconPacks.Avalonia.PackIconBoxIconsKind]"> -->
-        <Style Selector="^:PackIconBoxIcons">
-            <Setter Property="Template" Value="{DynamicResource IconPacks.Avalonia.PackIconBoxIcons.Template}" />
+        <!-- flipped icon data -->
+        <Style Selector="^:icon-data-flipped-vertically /template/ Viewbox#PART_ViewBox">
+            <Setter Property="RenderTransform" Value="scale(1, -1)" />
         </Style>
+        
+        
     </ControlTheme>
 
     <ControlTheme x:Key="{x:Type iconPacks:PackIconControl}"

--- a/src/IconPacks.Avalonia/PackIconControl.xaml
+++ b/src/IconPacks.Avalonia/PackIconControl.xaml
@@ -1,11 +1,11 @@
-﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:iconPacks="urn:iconpacks-avalonia"
                     xmlns:converter="clr-namespace:IconPacks.Avalonia.Converter;assembly=IconPacks.Avalonia.Core"
                     x:ClassModifier="internal">
     
     <Design.PreviewWith>
-        <iconPacks:PackIconBoxIcons Kind="RegularBowlingBall" />
+        <iconPacks:PackIconControl Kind="{x:Static iconPacks:PackIconBoxIconsKind.SolidBowlHot}" />
     </Design.PreviewWith>
     
     
@@ -21,7 +21,6 @@
                          Margin="{TemplateBinding Padding}">
                     <Path x:Name="PART_IconPath"
                           Data="{Binding Data, RelativeSource={RelativeSource TemplatedParent}, Mode=OneWay, Converter={x:Static converter:NullToUnsetValueConverter.Instance}}"
-                          Fill="{TemplateBinding Foreground}"
                           Stretch="Uniform"
                           UseLayoutRounding="False" />
                 </Viewbox>
@@ -166,6 +165,19 @@
         <Setter Property="VerticalAlignment" Value="Top" />
         <Setter Property="UseLayoutRounding" Value="False" />
         <Setter Property="Template" Value="{DynamicResource IconPacks.Avalonia.PackIconControl.Template}" />
+        
+        <!-- icon is filled -->
+        <Style Selector="^:icon-filled /template/ Path#PART_IconPath">
+            <Setter Property="Fill" Value="{Binding Foreground, RelativeSource={RelativeSource Mode=TemplatedParent}}" />
+        </Style>
+
+        <!-- icon is outlined -->
+        <Style Selector="^:icon-outlined /template/ Path#PART_IconPath">
+            <Setter Property="Stroke" Value="{Binding Foreground, RelativeSource={RelativeSource Mode=TemplatedParent}}" />
+            <Setter Property="StrokeThickness" Value="2" />
+            <Setter Property="StrokeLineCap" Value="Round" />
+            <Setter Property="StrokeJoin"  Value="Round" />
+        </Style>
 
         <!-- flipped icon data -->
         <Style Selector="^:icon-data-flipped-vertically /template/ Viewbox#PART_ViewBox">


### PR DESCRIPTION
- moved pseudo-class definition to base class
- add a method to update the classes as needed per icon data
- update styles accordingly 

this is how it looks in DevTools [F12]: 

![image](https://github.com/user-attachments/assets/74182bae-a0c9-49b2-9180-01d3524100a3)

This PR depends on #2 